### PR TITLE
ファイル末尾に空行を挿入するようにした

### DIFF
--- a/build/edit_all.sh
+++ b/build/edit_all.sh
@@ -21,6 +21,7 @@ do
       | sed -e $replace_math \
       | sed -e $replace_paths \
       >"$tmpfile"
+    echo >>"$tmpfile"  # 段落の区切りをつけるためにファイル末尾に空行を挿入
     mv -f "$tmpfile" "$md"
   fi
 done


### PR DESCRIPTION
Markdown のパーサーが、段落の区切りを判別できず、
見出しが見出しにならないことがあるため（#43）。
