### PR TITLE
成果物の HTML に画像を埋め込むようにした

### DIFF
--- a/build/build_all.sh
+++ b/build/build_all.sh
@@ -9,7 +9,6 @@ $PANDOC_PDF \
   $target
 $PANDOC_HTML \
   --toc \
-  --self-contained \
   -o "${CIRCLE_ARTIFACTS:-.}/stan-reference-2.9.0-ja.html" \
   $target
 

--- a/build/build_all.sh
+++ b/build/build_all.sh
@@ -9,6 +9,7 @@ $PANDOC_PDF \
   $target
 $PANDOC_HTML \
   --toc \
+  --self-contained \
   -o "${CIRCLE_ARTIFACTS:-.}/stan-reference-2.9.0-ja.html" \
   $target
 

--- a/build/env.sh
+++ b/build/env.sh
@@ -16,5 +16,6 @@ export PANDOC_PDF="pandoc
 export PANDOC_HTML="pandoc
   -t html5
   --standalone
+  --self-contained
   --template=build/template.html"
 


### PR DESCRIPTION
成果物の HTML で画像が見られなかった問題で、 HTML を画像を埋め込むことで画像が表示できない問題に対応した。
リンクにすると GitHub への依存が高まるので、プロジェクトとしての独立性を保つために埋め込み方式とした。